### PR TITLE
Adding backslash to stdClass construction because we're using a namespace

### DIFF
--- a/src/codebird.php
+++ b/src/codebird.php
@@ -870,7 +870,7 @@ class Codebird
 
         $need_array = $this->_return_format == CODEBIRD_RETURNFORMAT_ARRAY;
         if ($reply == '[]') {
-            return $need_array ? array() : new stdClass;
+            return $need_array ? array() : new \stdClass;
         }
         $parsed = array();
         if ($method == 'users/profile_image/:screen_name') {


### PR DESCRIPTION
Without this the class is deemed to be within the Codebird namespace (eg. \Codebird\stdClass). This backslash means it has no namespace and should be used for standard php classes (eg. \DateTime, etc.)
