### PR TITLE
Fix README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ map to Codebird function calls. The general rules are:
     Examples:
     - ```statuses/show/:id``` maps to ```Codebird::statuses_show_ID('id=12345')```.
     - ```users/profile_image/:screen_name``` maps to
-      ```Codebird::users_profileImage_SCREEN_NAME('screen_name=jublonet')```.
+      `Codebird::users_profileImage_SCREEN_NAME('screen_name=jublonet')`.
 
 HTTP methods (GET, POST, DELETE etc.)
 -------------------------------------


### PR DESCRIPTION
I don't know why, but GitHub was choking on the markdown and making it impossible to read some of the examples.