### PR TITLE
bugfix, tweet ids on 32bit systems

### DIFF
--- a/src/codebird.php
+++ b/src/codebird.php
@@ -792,7 +792,7 @@ class Codebird
                 break;
             case CODEBIRD_RETURNFORMAT_JSON:
                 if ($httpstatus === 200) {
-                    $parsed = json_decode($reply);
+                    $parsed = json_decode($reply, false, 512, JSON_BIGINT_AS_STRING);
                     self::setBearerToken($parsed->access_token);
                 }
                 break;
@@ -1528,7 +1528,7 @@ class Codebird
                     return new \stdClass;
             }
         }
-        if (! $parsed = json_decode($reply, $need_array)) {
+        if (! $parsed = json_decode($reply, $need_array, 512, JSON_BIGINT_AS_STRING)) {
             if ($reply) {
                 if (stripos($reply, '<' . '?xml version="1.0" encoding="UTF-8"?' . '>') === 0) {
                     // we received XML...


### PR DESCRIPTION
Tweets ids are > 2^32 and converted to floats by default json_decode and it's impossible to work with:
json_decode("{'id': 587653889492553728}") =>
["id"]=> float(5.8765388949255E+17)

Works same on 64bit - returns integers.